### PR TITLE
Fixes grammar for June 2016 hackfest

### DIFF
--- a/content/news/2016-05-21-hackfest.md
+++ b/content/news/2016-05-21-hackfest.md
@@ -8,5 +8,5 @@ Author: Tom Most
 
 Come show us what you’ve been up to!
 Bring your projects, problems and persons for round-table discussion.
-We also welcome lightning talks if you’d like you present, but don’t have enough material for a full talk.
+We also welcome lightning talks if you’d like to present, but don’t have enough material for a full talk.
 A projector will be available (VGA).


### PR DESCRIPTION
There is a grammatical error on the June 2016 Hackfest description.